### PR TITLE
Use component-installer rather than riding on component's private API

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -1,8 +1,5 @@
 var path = require('path');
-var component = require('component');
-var utils = component.utils;
-var log = utils.log;
-var error = utils.error;
+var Installer = require('component-installer');
 
 module.exports = install;
 
@@ -14,7 +11,7 @@ function report(pkg, options) {
   log('install', pkg.name + '@' + pkg.version);
 
   pkg.on('error', function(err){
-    if (404 != err.status) utils.fatal(err.stack);
+    if (404 != err.status) fatal(err.stack);
 
     if (err.fatal) {
       error(err.message);
@@ -43,19 +40,66 @@ function report(pkg, options) {
 function install(filename) {
   console.log('Installing components specified in component-shrinkwrap.json...');
 
-  var wrap = require(path.resolve(filename));
-  var conf = require(path.resolve('component.json'));
+  var deps = require(path.resolve(filename)).components;
+  var installer = new Installer(path.dirname(filename));
 
-  conf.remotes = conf.remotes || [];
-  conf.remotes.push('https://raw.github.com');
-  wrap.components.forEach(function(c) {
-
-    var pkg = component.install(c.name, c.version, {
-      remotes: conf.remotes
-    });
-
-    report(pkg);
-
-    pkg.install();
+  installer.on('package', report);
+  deps.forEach(function (dep) {
+    installer.installPackage(dep.name, dep.version);
   });
+}
+
+/**
+ * Output fatal error message and exit.
+ *
+ * Taken from component/lib/utils.js
+ *
+ * @param {String} msg
+ * @api private
+ */
+
+function fatal() {
+  console.error();
+  error.apply(null, arguments);
+  console.error();
+  process.exit(1);
+}
+
+/**
+ * Log the given `type` with `msg`.
+ *
+ * Slightly modified version of component/lib/utils.js
+ *
+ * @param {String} type
+ * @param {String} msg
+ * @api public
+ */
+
+function log(type, msg) {
+  var color = 'error' == type
+    ? '31'
+    : '36';
+
+  var w = 10;
+  var len = Math.max(0, w - type.length);
+  var pad = Array(len + 1).join(' ');
+  var fmt = '  \033[' + color + 'm%s\033[m : \033[90m%s\033[m';
+  if ('error' == type) {
+    console.error(fmt, pad + type, msg);
+  } else {
+    console.log(fmt, pad + type, msg);
+  }
+}
+
+/**
+ * Output error message.
+ *
+ * Slightly modified version of component/lib/utils.js
+ *
+ * @param {String} msg
+ * @api private
+ */
+
+function error(msg) {
+  log('error', msg);
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "commander": "~1",
-    "component": "~0"
+    "component-installer": "~0"
   },
   "peerDependencies": {
     "component": "*"


### PR DESCRIPTION
This allows us to (more easily) stay current with component's
installation processes and reduces our dependency footprint. :)

Closes #1.
