### PR TITLE
Add default behavior to component-shrinkwrap(1)

### DIFF
--- a/bin/component-shrinkwrap
+++ b/bin/component-shrinkwrap
@@ -5,6 +5,7 @@
  */
 
 var program = require('commander');
+var fs = require('fs');
 var shrinkwrap = require('..');
 
 // parse argv
@@ -16,10 +17,10 @@ program
 
 var filename = 'component-shrinkwrap.json';
 
-if (program.save) {
-	shrinkwrap.save(filename);
-} else if (program.install) {
-	shrinkwrap.install(filename);
+if (program.save || (!program.install && fs.existsSync('components'))) {
+  shrinkwrap.save(filename);
+} else if (program.install || fs.existsSync(filename)) {
+  shrinkwrap.install(filename);
 } else {
-	program.help();
+  program.help();
 }


### PR DESCRIPTION
Allows us to use the binary without specifying `--save` or `--install`.
If the component-shrinkwrap.json file is present, we'll install the
listed components.  Otherwise, if the component directory is present,
we'll build the component-shrinkwrap.json.

This does not change the existing API, just adds some sugar around it.
